### PR TITLE
chore(ng-update): update angular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,13 +18,13 @@
         "zone.js": "~0.13.0"
       },
       "devDependencies": {
-        "@angular-devkit/build-angular": "^15.2.6",
+        "@angular-devkit/build-angular": "^15.2.7",
         "@angular-eslint/builder": "^15.2.1",
         "@angular-eslint/eslint-plugin": "^15.2.1",
         "@angular-eslint/eslint-plugin-template": "^15.2.1",
         "@angular-eslint/schematics": "^15.2.1",
         "@angular-eslint/template-parser": "^15.2.1",
-        "@angular/cli": "^15.2.6",
+        "@angular/cli": "^15.2.7",
         "@angular/compiler-cli": "^15.2.8",
         "@angular/language-service": "^15.2.8",
         "@types/jasmine": "~4.3.1",
@@ -60,12 +60,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1502.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1502.6.tgz",
-      "integrity": "sha512-n4oJ9vzFWwabf+AfgqqevVzdJhNKNCav7ytefjD/Y01vkNwlXqWnHcvyyHCLkVibJ6WR8J9lK4t77j/HFlDvWQ==",
+      "version": "0.1502.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1502.7.tgz",
+      "integrity": "sha512-MzB6D/yUo6cBJfQ31zNDHJ3C3iKmBtxP3i9WIRnnkZwS1VUfO8OX3TZ6lycYbREF1oL/AQ/r9GK+KA5DNEBSAw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "15.2.6",
+        "@angular-devkit/core": "15.2.7",
         "rxjs": "6.6.7"
       },
       "engines": {
@@ -93,15 +93,15 @@
       "dev": true
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "15.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-15.2.6.tgz",
-      "integrity": "sha512-OmMcdXXUrAdZNxwxDE8SUx1FMcq9FyMnrSv1PmP9sHPBoxAdBVc/qNdGA9V7C5yHvWHGgzsx7ZK5TDuvifzS5g==",
+      "version": "15.2.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-15.2.7.tgz",
+      "integrity": "sha512-zZ+tlt5aNGY9APUdjQHeVFJpVLeixlZRNHmfdXD+rN4WR2q9E0pTvLUThrkOmO8YrVyGbdvcw1O7XNdL+3b02w==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.0",
-        "@angular-devkit/architect": "0.1502.6",
-        "@angular-devkit/build-webpack": "0.1502.6",
-        "@angular-devkit/core": "15.2.6",
+        "@angular-devkit/architect": "0.1502.7",
+        "@angular-devkit/build-webpack": "0.1502.7",
+        "@angular-devkit/core": "15.2.7",
         "@babel/core": "7.20.12",
         "@babel/generator": "7.20.14",
         "@babel/helper-annotate-as-pure": "7.18.6",
@@ -113,7 +113,7 @@
         "@babel/runtime": "7.20.13",
         "@babel/template": "7.20.7",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "15.2.6",
+        "@ngtools/webpack": "15.2.7",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.13",
         "babel-loader": "9.1.2",
@@ -371,12 +371,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1502.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1502.6.tgz",
-      "integrity": "sha512-X7XQ11QDz2Bs5qpJ3a5glIytvI+S74ORQxdzvT6a6KB8ayW0SgZEhTwD+GF7pa5My8draIaXBGzzQR1qmpWK5Q==",
+      "version": "0.1502.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1502.7.tgz",
+      "integrity": "sha512-sNE4t4shSwxagqm+jdojbkYfuo/CHNMi4faItDWTTsCOf9wQxCxV4Waxee4akAkv3K6fzrnZy3ad/oQQMUl0Iw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1502.6",
+        "@angular-devkit/architect": "0.1502.7",
         "rxjs": "6.6.7"
       },
       "engines": {
@@ -408,9 +408,9 @@
       "dev": true
     },
     "node_modules/@angular-devkit/core": {
-      "version": "15.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-15.2.6.tgz",
-      "integrity": "sha512-YVTWZ+M+xNKdFX4EnY9QX49PZraawiaA0iTd2CUW8ZoTUvU7yOGMKZLSdz6aokTMRVfm0449wt6YL994ibOo1g==",
+      "version": "15.2.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-15.2.7.tgz",
+      "integrity": "sha512-k2MKUm4ygTD9+89neqMmBphDr0o8Tp9RtgfzbS8VHgGkGYlbu0KPsxHyHB3Mvzl1EkSz6EHyrU3t89m+Rcj1lw==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -474,12 +474,12 @@
       "dev": true
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "15.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-15.2.6.tgz",
-      "integrity": "sha512-f7VgnAcok7AwR/DhX0ZWskB0rFBo/KsvtIUA2qZSrpKMf8eFiwu03dv/b2mI0vnf+1FBfIQzJvO0ww45zRp6dA==",
+      "version": "15.2.7",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-15.2.7.tgz",
+      "integrity": "sha512-umQ+SgEMjqPHimHOBVhDn5NNGVoMLKQkI2fwbENXV72BqQqdh1K3D4QSNlUXitTaH0NEZZaAawE1vZHzzeAoNA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "15.2.6",
+        "@angular-devkit/core": "15.2.7",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.29.0",
         "ora": "5.4.1",
@@ -1122,15 +1122,15 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "15.2.6",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-15.2.6.tgz",
-      "integrity": "sha512-wNkQ/qCVbd4pERaGVagKJPifEvjRNY5otwsd4iRVubY/XOcIHcYChUThZwgQdVfNAImfJPMZNrhbGxejuWLA9w==",
+      "version": "15.2.7",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-15.2.7.tgz",
+      "integrity": "sha512-gGUIjaVN//bO72zRK3GNcCRVeism56BCRfkXSywKedCWFK4IZsatIL1IXT6OiJC22NsUCMaAFPD0wygSUCZaig==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1502.6",
-        "@angular-devkit/core": "15.2.6",
-        "@angular-devkit/schematics": "15.2.6",
-        "@schematics/angular": "15.2.6",
+        "@angular-devkit/architect": "0.1502.7",
+        "@angular-devkit/core": "15.2.7",
+        "@angular-devkit/schematics": "15.2.7",
+        "@schematics/angular": "15.2.7",
         "@yarnpkg/lockfile": "1.1.0",
         "ansi-colors": "4.1.3",
         "ini": "3.0.1",
@@ -3676,9 +3676,9 @@
       "dev": true
     },
     "node_modules/@ngtools/webpack": {
-      "version": "15.2.6",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-15.2.6.tgz",
-      "integrity": "sha512-I+kekKItfsCLdX+ZjjmsWqd0AyoYGTQPjlbQAiPtmdH73/rfPOF4Q/3AU4tzTdn0n0GXqZWv6VOs91w99ydi0A==",
+      "version": "15.2.7",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-15.2.7.tgz",
+      "integrity": "sha512-iUCSR03PzGSpwwZ5soioTIWsTPBayzkZfhKMkfz1RqtkbcxC4I07NRoQ1djofhsYyW2I1n7XS8w3K7NILtN3gQ==",
       "dev": true,
       "engines": {
         "node": "^14.20.0 || ^16.13.0 || >=18.10.0",
@@ -4010,13 +4010,13 @@
       "dev": true
     },
     "node_modules/@schematics/angular": {
-      "version": "15.2.6",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-15.2.6.tgz",
-      "integrity": "sha512-OcBUvVAxZEMBX+fi0ytybeAdmStra+GwtlvipS70yOxcAgJ84ZrnZGN7a072cCVQcq7AgqUfssnyqCx1wu+yCg==",
+      "version": "15.2.7",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-15.2.7.tgz",
+      "integrity": "sha512-5fC6Es6HWpvmCnpPwTxHQq6KQuxtPaheFgoElHJM6uBgJDTr993MIw/3FsZvqLkO9hv/yWbr4gilqjEoesJSWg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "15.2.6",
-        "@angular-devkit/schematics": "15.2.6",
+        "@angular-devkit/core": "15.2.7",
+        "@angular-devkit/schematics": "15.2.7",
         "jsonc-parser": "3.2.0"
       },
       "engines": {
@@ -4101,9 +4101,9 @@
       }
     },
     "node_modules/@types/connect-history-api-fallback": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz",
-      "integrity": "sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
+      "integrity": "sha512-4x5FkPpLipqwthjPsF7ZRbOv3uoLUFkTA9G9v583qi4pACvq0uTELrB8OLUzPWUI4IJIyvM85vzkV1nyiI2Lig==",
       "dev": true,
       "dependencies": {
         "@types/express-serve-static-core": "*",
@@ -4161,20 +4161,21 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.33",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
-      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
+      "version": "4.17.34",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.34.tgz",
+      "integrity": "sha512-fvr49XlCGoUj2Pp730AItckfjat4WNb0lb3kfrLWffd+RLeoGAMsq7UOy04PAPtoL01uKwcp6u8nhzpgpDYr3w==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
-        "@types/range-parser": "*"
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/http-proxy": {
-      "version": "1.17.10",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.10.tgz",
-      "integrity": "sha512-Qs5aULi+zV1bwKAg5z1PWnDXWmsn+LxIvUGv6E2+OOMYhclZMO+OXd9pYVf2gLykf2I7IV2u7oTHwChPNsvJ7g==",
+      "version": "1.17.11",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.11.tgz",
+      "integrity": "sha512-HC8G7c1WmaF2ekqpnFq626xd3Zz0uvaqFmBJNRZCGEZCXkvSdJoNFn/8Ygbd9fKNQj8UzLdCETaI0UWPAjK7IA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -4193,9 +4194,9 @@
       "dev": true
     },
     "node_modules/@types/mime": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
-      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -4255,6 +4256,16 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/serve-index": {
       "version": "1.9.1",
@@ -7244,9 +7255,9 @@
       "dev": true
     },
     "node_modules/dns-packet": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.5.0.tgz",
-      "integrity": "sha512-USawdAUzRkV6xrqTjiAEp6M9YagZEzWcSUaZTcIFAiyQWW1SoI6KyId8y2+/71wbgHKQAKd+iupLv4YvEwYWvA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.0.tgz",
+      "integrity": "sha512-rza3UH1LwdHh9qyPXp8lkwpjSNk/AMD3dPytUoRoqnypDUhY0xvbdmVhWOfxO68frEfV9BU8V12Ez7ZsHGZpCQ==",
       "dev": true,
       "dependencies": {
         "@leichtgewicht/ip-codec": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "zone.js": "~0.13.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^15.2.6",
+    "@angular-devkit/build-angular": "^15.2.7",
     "@angular-eslint/builder": "^15.2.1",
     "@angular-eslint/eslint-plugin": "^15.2.1",
     "@angular-eslint/eslint-plugin-template": "^15.2.1",
     "@angular-eslint/schematics": "^15.2.1",
     "@angular-eslint/template-parser": "^15.2.1",
-    "@angular/cli": "^15.2.6",
+    "@angular/cli": "^15.2.7",
     "@angular/compiler-cli": "^15.2.8",
     "@angular/language-service": "^15.2.8",
     "@types/jasmine": "~4.3.1",


### PR DESCRIPTION
[ng-update](https://github.com/fast-facts/ng-update) 🤖 has automatically run `ng update` for you and baked this hot 🔥 PR , ready to merge.

<details>
  <summary>Ng Update Output:</summary>

    Using package manager: npm
Collecting installed dependencies...
Found 34 dependencies.
    We analyzed your package.json, there are some packages to update:
    
      Name                                    Version                  Command to update
     -------------------------------------------------------------------------------------
      @angular/cli                            15.2.6 -> 15.2.7         ng update @angular/cli
    
    There might be additional packages which don't provide 'ng update' capabilities that are outdated.
    You can update the additional packages by running the update command of your package manager.


  </summary>
</details>